### PR TITLE
add enumerations section

### DIFF
--- a/templates/grpc/enum.md
+++ b/templates/grpc/enum.md
@@ -1,0 +1,6 @@
+## {{ enumName }}
+{{ enum.description }}
+
+Alias            | Code               | Description
+---------------- | ------------------ | ----------- {% for param in enum.params %}
+<code>{{ param.name }}</code> | <code>{{ param.number }}</code> | {{ param.description }} {% endfor %}

--- a/templates/grpc/index.md
+++ b/templates/grpc/index.md
@@ -68,3 +68,8 @@ Alternatively, the REST documentation can be found [here](./rest).
 {% for messageName, message in messages.items() %}
 {% include 'grpc/message.md' %}
 {% endfor %}
+
+# Enumerations
+{% for enumName, enum in enums.items() %}
+{% include 'grpc/enum.md' %}
+{% endfor %}


### PR DESCRIPTION
Links to enums were broken, this should fix them.

Came up while developing [lighter-doc](https://lighter-doc.inbitcoin.it/) for [lighter](https://gitlab.com/inbitcoin/lighter).

Given our doc generation system was inspired by yours, it felt natural to give this fix back.